### PR TITLE
Fix clang include paths problem

### DIFF
--- a/includepathsFileExampleNginx.txt
+++ b/includepathsFileExampleNginx.txt
@@ -1,0 +1,12 @@
+/include
+/event
+/event/modules
+/http
+/http/modules
+/http/modules/perl
+/http/v2
+/mail
+/os/unix
+/stream
+/src/core/
+/src/os/unix/


### PR DESCRIPTION
If clang can't find the type definition for a parameter used in
the function call, then the ASTnode for the call is not added to
the AST. This was happening, because clang had problems with
the include paths.

This fix offers the user the option to provide his file with include
paths, but this is only optional. The paths from the file will
be relative to the rootdir. If the file with paths won't be provided,
then the program will work as usually and it will only print a warning.
This is probably not the best solution, but the only I have found.

Signed-off-by: Constantin Raducanu <raducanu.costi@gmail.com>